### PR TITLE
Add getting started to readme and link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Pub Release performs the following operations:
 * Publishes the package to pub.dev.
 * Run pre/post release 'hook' scripts.
 
-## 
-
-## 
+## Getting Started
+- Install it globally with `pub global activate pub_release`
+- Read the [full documentation](https://github.com/bsutton/pub_release/blob/master/SUMMARY.md) to learn how to use it
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@ Pub Release performs the following operations:
 * Run pre/post release 'hook' scripts.
 
 ## Getting Started
-- Install it globally with `pub global activate pub_release`
+- Install Pub Release globally with `dart pub global activate pub_release`
 - Read the [full documentation](https://github.com/bsutton/pub_release/blob/master/SUMMARY.md) to learn how to use it
 


### PR DESCRIPTION
It looks like you have added lots of nice documentation on how to use this package. Let's link to it from the readme so people can get to the docs and figure out learn how to use it, right from https://pub.dev/packages/pub_release